### PR TITLE
debug replaceParagraph

### DIFF
--- a/src/formatters.js
+++ b/src/formatters.js
@@ -92,7 +92,7 @@ function replaceOl (doc) {
  * @return {String}           [description]
  */
 function replaceParagraph (doc) {
-  return makeRegex(pRegex, doc);
+  return makeRegex(pRegex, doc, null, '\n\n');
 }
 
 /**


### PR DESCRIPTION
In markdown, to create a paragraph we need to add a double line breaker (\n\n) at the end of the paragraph